### PR TITLE
Add nightly TST1 sync workflow

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -1,0 +1,42 @@
+name: Nightly sync from TST1
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run sync
+        run: sh sync
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/nightly-sync-from-tst1
+          delete-branch: true
+          commit-message: "chore(sync): sync from TST1"
+          title: "Sync from TST1"
+          body: |
+            Automated nightly sync from TST1.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ It is good to sync text from tst1 to get the latest changes from the business. J
 ```bash
 sh sync
 ```
+
+A GitHub Action also runs this sync automatically every midnight (00:00 UTC) and opens or updates a PR titled `Sync from TST1` when it detects changes.


### PR DESCRIPTION
## Why
This repository already includes a `sync` script for pulling localization updates from TST1, but it currently depends on someone running it manually. Automating that flow keeps the repo up to date and surfaces incoming content changes as a reviewable pull request.

## What changed
- add a scheduled GitHub Actions workflow that runs every day at 00:00 UTC and can also be triggered manually
- install project dependencies and run `sh sync` inside the workflow
- create or update an automated PR titled `Sync from TST1` only when the sync produces file changes
- document the nightly sync behavior in the README

## Notes
The workflow uses a dedicated automation branch (`chore/nightly-sync-from-tst1`) for the generated updates and grants the permissions needed to push changes and open the PR.