### PR TITLE
SB-31126: Show add card after onboarding finish

### DIFF
--- a/json/onboarding/edisponent/all_cs.json
+++ b/json/onboarding/edisponent/all_cs.json
@@ -83,7 +83,8 @@
             "titleLoading": "Teď to musíme podepsat my, chvilku strpení prosím.",
             "detail": "Kartu k účtu si můžete sjednat ve Smart Bance v sekci Karty, Nová karta.\n\nPro přihlášení do Internet Banky použijte ID, které jsme Vám zaslali e-mailem a heslo z SMS.",
             "detailStatutory": "Právě jsme vás přidali jako statutárního zástupce společnosti {0}. Do Internet Banky se můžete přihlásit pomocí ID z e-mailu a hesla z SMS.",
-            "primaryButton": "Pokračovat"
+            "primaryButton": "Chci kartu hned",
+            "secondaryButton": "Kartu si sjednám později"
         }
     }
 }

--- a/json/onboarding/edisponent/all_en.json
+++ b/json/onboarding/edisponent/all_en.json
@@ -79,7 +79,7 @@
             "primaryButton": "Terminate onboarding"
         },
         "victoryParentProcessPO": {
-             "title": "Done! Your Konto PRO business account has been opened",
+            "title": "Done! Your Konto PRO business account has been opened",
             "titleLoading": "Now it’s our turn to sign it. Please bear with us for a moment.",
             "detail": "You can get a card for your account in Smart Banka under Cards, New Card.\n\nTo log in to Internet Banka, use the ID we sent you by email and the password you received by SMS.",
             "detailStatutory": "We have just added you as an authorized representative of the company {0}. You can log into Internet Banka using the ID from the email and the password from the SMS.",

--- a/json/onboarding/edisponent/all_en.json
+++ b/json/onboarding/edisponent/all_en.json
@@ -79,11 +79,12 @@
             "primaryButton": "Terminate onboarding"
         },
         "victoryParentProcessPO": {
-            "title": "Hotovo! Konto PRO podnikání máte založeno",
-            "titleLoading": "Teď to musíme podepsat my, chvilku strpení prosím.",
-            "detail": "Kartu k účtu si můžete sjednat ve Smart Bance v sekci Karty, Nová karta.\n\nPro přihlášení do Internet Banky použijte ID, které jsme Vám zaslali e-mailem a heslo z SMS.",
+             "title": "Done! Your Konto PRO business account has been opened",
+            "titleLoading": "Now it’s our turn to sign it. Please bear with us for a moment.",
+            "detail": "You can get a card for your account in Smart Banka under Cards, New Card.\n\nTo log in to Internet Banka, use the ID we sent you by email and the password you received by SMS.",
             "detailStatutory": "We have just added you as an authorized representative of the company {0}. You can log into Internet Banka using the ID from the email and the password from the SMS.",
-            "primaryButton": "Pokračovat"
+            "primaryButton": "I want the card now",
+            "secondaryButton": "I'll get the card later"
         }
     }
 }


### PR DESCRIPTION
Added secondary button for parent process PO_ONBOARDING in edisponent finish victory to allow user to chose add card immediately or later