### PR TITLE
fix(localization): bold identification and password labels in sign-in prompts

### DIFF
--- a/json/sb-pairing/all_cs.json
+++ b/json/sb-pairing/all_cs.json
@@ -155,7 +155,7 @@
                 },
                 {
                     "id": 3,
-                    "label": "Zadejte své <a href=\"id\">Identifikační číslo (ID)</a>, <a href=\"password\">heslo</a> a přihlaste se."
+                    "label": "Zadejte své <a href=\"id\"><b>Identifikační číslo (ID)</b></a>, <a href=\"password\"><b>heslo</b></a> a přihlaste se."
                 },
                 {
                     "id": 4,

--- a/json/sb-pairing/all_en.json
+++ b/json/sb-pairing/all_en.json
@@ -132,7 +132,7 @@
                 },
                 {
                     "id": 3,
-                    "label": "Enter your <a href=\"id\">Identification number (ID)</a>, <a href=\"password\">password</a> and sign in."
+                    "label": "Enter your <a href=\"id\"><b>Identification number (ID)</b></a>, <a href=\"password\"><b>password</b></a> and sign in."
                 },
                 {
                     "id": 4,


### PR DESCRIPTION
https://www.figma.com/design/GCrN1rReBirfTWWKHMuZWs/P%C3%A1rov%C3%A1n%C3%AD-SB?node-id=349-9553&m=dev
