### PR TITLE
Fix nightly sync workflow shell

### DIFF
--- a/.github/workflows/nightly-sync.yml
+++ b/.github/workflows/nightly-sync.yml
@@ -29,7 +29,8 @@ jobs:
         run: npm ci
 
       - name: Run sync
-        run: sh sync
+        shell: bash
+        run: ./sync
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Why
The nightly sync workflow was invoking the sync script with `sh`, which runs it under `/bin/sh` instead of bash. That caused the action to fail immediately on `set -o pipefail`, so the scheduled sync could not complete.

## What changed
- run the sync step with `shell: bash`
- execute the script as `./sync` so it uses the script's bash-compatible setup

## Notes
This is a follow-up fix to the merged nightly sync workflow PR. It keeps the existing script unchanged and corrects only the workflow invocation.