### PR TITLE
feat(ININ-808): DIP denied FOP/PO screen texts

### DIFF
--- a/json/investments/all_cs.json
+++ b/json/investments/all_cs.json
@@ -10094,6 +10094,11 @@
                 "title": "Omlouváme se, tak tohle nevyšlo",
                 "subtitle": "Bohužel nastala neočekávaná chyba a není možné pokračovat. \nProsím, zkuste to později.",
                 "primaryButton": "Zpět na Přehled"
+            },
+            "deniedFopPo": {
+                "title": "Dlouhodobý investiční produkt si můžete sjednat v osobním profilu",
+                "subtitle": "Tento produkt je určený pouze pro fyzické osoby. Pro jeho sjednání se přepněte do osobního profilu.",
+                "primaryButton": "Zpět na investice"
             }
         }
     }

--- a/json/investments/all_en.json
+++ b/json/investments/all_en.json
@@ -10080,6 +10080,11 @@
                 "title": "Sorry, something went wrong",
                 "subtitle": "Unfortunately, an unexpected error occurred and we can’t continue right now.\nPlease try again later.",
                 "primaryButton": "Back to Investments"
+            },
+            "deniedFopPo": {
+                "title": "Open a Long-term Investment Product from your personal profile",
+                "subtitle": "This product is only available to personal customers. Switch to your personal profile to open it.",
+                "primaryButton": "Back to Investments"
             }
         }
     }


### PR DESCRIPTION
## ININ-808

Texts for the new DIP onboarding denial screen shown when
`investment/dip/onboarding/screenflow/setup` returns `"goToScreen": "IO_DENIED_FOP_PO"`
(client is FOP / PO and cannot open a DIP from that profile).

Adds `screens.dipOnboarding.deniedFopPo` to `json/investments/all_cs.json` and `all_en.json`,
shaped like the existing `processFail` / `longTermProcess` siblings.

| key | CS | EN |
|---|---|---|
| `title` | Dlouhodobý investiční produkt si můžete sjednat v osobním profilu | Open a Long-term Investment Product from your personal profile |
| `subtitle` | Tento produkt je určený pouze pro fyzické osoby. Pro jeho sjednání se přepněte do osobního profilu. | This product is only available to personal customers. Switch to your personal profile to open it. |
| `primaryButton` | Zpět na investice | Back to Investments |

Source: Figma `xeD4jOwQLzXHFWXMfXvRc0` — CZ node `9863:26350`, EN node `9990:11996`.

Note: the EN title uses "Long-term" (lowercase `t`), matching Figma, even though other EN keys
in this file use "Long-Term".

Android side: MONETA-SmartBanka/android branch `feat/ININ-808/victory`.