### PR TITLE
[SBO-6955] MPS interest cashback campaign localisation

### DIFF
--- a/json/sme-multi-lending/all_cs.json
+++ b/json/sme-multi-lending/all_cs.json
@@ -334,6 +334,7 @@
                 "loanAmount": "Půjčíme Vám",
                 "instalmentsCount": "na dobu",
                 "instalmentAmount": "s měsíční splátkou",
+                "interestCashback": "Navíc za první 3 měsíce bez úroku ušetříte",
                 "posSavings": {
                     "title": "Čím vyšší úvěr a delší splatnost, tím větší sleva",
                     "description": "Ušetřeno díky sjednání online",
@@ -789,6 +790,7 @@
             "packages": {
                 "expres": {
                     "title": "Splátkový úvěr - Expres Business",
+                    "interestCashback": "Splácejte včas a <b>vrátíme Vám zaplacené úroky za první 3 měsíce.</b>",
                     "detail": "<b>{amount}</b> bude připsáno nejpozději během následujícího pracovního dne na Váš účet <b>{account}</b>.\n\nPrvní splátka ve výši <b>{installment}</b> včetně pojištění automaticky odejde <b>{date}</b>.",
                     "detailWoInsurance": "<b>{amount}</b> bude připsáno nejpozději během následujícího pracovního dne na Váš účet <b>{account}</b>.\n\nPrvní splátka ve výši <b>{installment}</b> automaticky odejde <b>{date}</b>."
                 },

--- a/json/sme-multi-lending/all_en.json
+++ b/json/sme-multi-lending/all_en.json
@@ -334,6 +334,7 @@
                 "loanAmount": "Půjčíme Vám",
                 "instalmentsCount": "na dobu",
                 "instalmentAmount": "s měsíční splátkou",
+                "interestCashback": "Navíc za první 3 měsíce bez úroku ušetříte",
                 "posSavings": {
                     "title": "Čím vyšší úvěr a delší splatnost, tím větší sleva",
                     "description": "Ušetřeno díky sjednání online",
@@ -789,6 +790,7 @@
             "packages": {
                 "expres": {
                     "title": "Splátkový úvěr - Expres Business",
+                    "interestCashback": "Splácejte včas a <b>vrátíme Vám zaplacené úroky za první 3 měsíce.</b>",
                     "detail": "<b>{amount}</b> bude připsáno nejpozději během následujícího pracovního dne na Váš účet <b>{account}</b>.\n\nPrvní splátka ve výši <b>{installment}</b> včetně pojištění automaticky odejde <b>{date}</b>.",
                     "detailWoInsurance": "<b>{amount}</b> bude připsáno nejpozději během následujícího pracovního dne na Váš účet <b>{account}</b>.\n\nPrvní splátka ve výši <b>{installment}</b> automaticky odejde <b>{date}</b>."
                 },


### PR DESCRIPTION
## Summary
Adds localization text keys for the interest cashback ATL campaign on the MPS (sme-multi-lending) flow — same campaign already localised for NTC in #400.

- `scenes.calculator.expres.interestCashback` — Calculator screen amount box label
- `scenes.victory.packages.expres.interestCashback` — Victory screen campaign paragraph

Key placement mirrors PR #400's precedent (after the sibling amount/title field).

Related Android PR: MONETA-SmartBanka/android#7254